### PR TITLE
0.7.0 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = ["./codegen/axum-starter-macro", "./examples/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 axum = "0.6"
-axum-starter-macro = { version = "0.6.1" }
+axum-starter-macro = { version = "0.6.1" ,path = "codegen/axum-starter-macro"}
 futures = "0.3"
 http-body = "0.4"
 hyper = { version = "0.14", features = ["server"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ http-body = "0.4"
 hyper = { version = "0.14", features = ["server"] }
 tap = "1"
 thiserror = "1"
+tokio = { version = "1.21.2", features = ["io-util"] }
 tower = "0.4"
 tracing = { version = "0.1", features = ["log"], optional = true }
 

--- a/codegen/axum-starter-macro/src/derive_config/code_gen.rs
+++ b/codegen/axum-starter-macro/src/derive_config/code_gen.rs
@@ -10,8 +10,8 @@ pub struct ImplAddress<'r> {
     associate_fetcher: bool,
 }
 
-impl<'r> From<(&'r Address,&'r syn::Ident)> for ImplAddress<'r> {
-    fn from((input,ident):(&'r Address,&'r syn::Ident)) -> Self {
+impl<'r> From<(&'r Address, &'r syn::Ident)> for ImplAddress<'r> {
+    fn from((input, ident): (&'r Address, &'r syn::Ident)) -> Self {
         let (ty, fetcher, ass) = match input {
             Address::Provide(Override::Explicit(Provider { ref ty })) => (Some(ty), None, false),
             Address::Provide(Override::Inherit) => (None, None, false),
@@ -89,7 +89,14 @@ pub struct ImplInitLog<'r> {
 
 impl<'r> From<&'r DeriveInput> for Option<ImplInitLog<'r>> {
     fn from(input: &'r DeriveInput) -> Self {
-        let Some(Logger{ func, error, associate }) = input.logger.as_ref() else {return  None;};
+        let Some(Logger {
+            func,
+            error,
+            associate,
+        }) = input.logger.as_ref()
+        else {
+            return None;
+        };
 
         Some(ImplInitLog {
             ident: &input.ident,

--- a/codegen/axum-starter-macro/src/derive_config/derive_inputs.rs
+++ b/codegen/axum-starter-macro/src/derive_config/derive_inputs.rs
@@ -6,7 +6,8 @@ use crate::utils::check_callable_expr;
 #[derive(Debug, darling::FromDeriveInput)]
 #[darling(attributes(conf), supports(struct_named))]
 pub struct DeriveInput {
-    pub(super) address: Address,
+    #[darling(default)]
+    pub(super) address: Option<Address>,
     #[darling(default)]
     pub(super) logger: Option<Logger>,
     #[darling(default)]

--- a/codegen/axum-starter-macro/src/derive_config/mod.rs
+++ b/codegen/axum-starter-macro/src/derive_config/mod.rs
@@ -15,7 +15,7 @@ pub fn provider_derive(derive_input: DeriveInput) -> darling::Result<proc_macro:
     let config =
         <self::derive_inputs::DeriveInput as FromDeriveInput>::from_derive_input(&derive_input)?;
 
-    let address = ImplAddress::from(&config);
+    let address = config.address.as_ref().map(|address|ImplAddress::from((address,&config.ident)));
     let logger = Option::<ImplInitLog>::from(&config);
     let server = ImplServerEffect::from(&config);
     Ok(quote::quote! {

--- a/codegen/axum-starter-macro/src/derive_config/mod.rs
+++ b/codegen/axum-starter-macro/src/derive_config/mod.rs
@@ -15,7 +15,10 @@ pub fn provider_derive(derive_input: DeriveInput) -> darling::Result<proc_macro:
     let config =
         <self::derive_inputs::DeriveInput as FromDeriveInput>::from_derive_input(&derive_input)?;
 
-    let address = config.address.as_ref().map(|address|ImplAddress::from((address,&config.ident)));
+    let address = config
+        .address
+        .as_ref()
+        .map(|address| ImplAddress::from((address, &config.ident)));
     let logger = Option::<ImplInitLog>::from(&config);
     let server = ImplServerEffect::from(&config);
     Ok(quote::quote! {

--- a/examples/prepare_expand.rs
+++ b/examples/prepare_expand.rs
@@ -13,7 +13,7 @@ use axum::{
     extract::{FromRef, Path, State},
     routing::get,
 };
-use axum_starter_macro::Configure;
+
 use futures::FutureExt;
 use hyper::server::accept::Accept;
 use hyper::server::conn::AddrIncoming;

--- a/examples/prepare_expand.rs
+++ b/examples/prepare_expand.rs
@@ -13,14 +13,15 @@ use axum::{
     extract::{FromRef, Path, State},
     routing::get,
 };
+use axum_starter_macro::Configure;
 
 use futures::FutureExt;
 use hyper::server::accept::Accept;
 use hyper::server::conn::AddrIncoming;
-use log::{info, Level, log};
+use log::{info, Level};
 use tokio::signal::ctrl_c;
 
-use axum_starter::{BindServe, ConfigureServerEffect, FromStateCollector, LoggerInitialization, prepare, PrepareRouteEffect, PrepareStateEffect, Provider, router::Route, ServerPrepare, state::AddState, StateCollector, TypeNotInState};
+use axum_starter::{BindServe, FromStateCollector, prepare, PrepareRouteEffect, PrepareStateEffect, Provider, router::Route, ServerPrepare, state::AddState, StateCollector, TypeNotInState};
 
 #[tokio::main]
 async fn main() {
@@ -93,25 +94,17 @@ fn adding_echo<B, S>() -> impl PrepareRouteEffect<S, B>
     )
 }
 
-#[derive(Debug, Provider)]
-// #[conf(
-// logger(error = "log::SetLoggerError", func = "simple_logger::init", associate),
-// server
-// )]
+#[derive(Debug, Provider,Configure)]
+#[conf(
+logger(error = "log::SetLoggerError", func = "||simple_logger::init_with_level(Level::Info)",associate),
+server
+)]
 pub struct Config {
     #[provider(transparent)]
     id: i32,
     #[provider(transparent, ref)]
     name: String,
 }
-
-impl LoggerInitialization for Config { type Error = log::SetLoggerError;
-    fn init_logger(&self) -> Result<(), Self::Error> {
-        simple_logger::init_with_level(Level::Info)
-    } }
-
-
-impl<A:Accept> ConfigureServerEffect<A> for Config {}
 
 impl BindServe for Config {
     type A = LogIpAddrIncome;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -149,7 +149,9 @@ fn on_fly_state() -> InFlight {
 
     tokio::spawn(async move {
         loop {
-            let Some(data) = receive.recv().await else{break;};
+            let Some(data) = receive.recv().await else {
+                break;
+            };
 
             sender2.send(data).ok();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub use axum_starter_macro::{prepare, Configure, FromStateCollector, Provider};
 pub use config_provide::provider::Provider;
 pub use effect_utils::{router, state};
 pub use prepare_sets::{concurrent_set::ConcurrentPrepareSet, serial_set::SerialPrepareSet};
+pub use hyper::server::accept::Accept;
 
 pub use hyper::server::{conn::AddrIncoming, Builder};
 /// [`Prepare`](crate::Prepare) return type, helper for macro code gen

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use prepare_behave::effect_traits::{
 };
 pub use server_prepare::{
     ConfigureServerEffect, LoggerInitialization, PrepareError, PrepareStartError, ServeAddress,
-    ServerPrepare,
+    ServerPrepare,BindServe
 };
 pub use server_ready::ServerReady;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ pub use prepare_behave::effect_traits::{
     FalliblePrepare, Prepare, PrepareMiddlewareEffect, PrepareRouteEffect, PrepareStateEffect,
 };
 pub use server_prepare::{
-    BindServe, ConfigureServerEffect, LoggerInitialization, PrepareError, PrepareStartError,
-    ServeAddress, ServerPrepare,PrepareDecorator
+    BindServe, ConfigureServerEffect, LoggerInitialization, PrepareDecorator, PrepareError,
+    PrepareStartError, ServeAddress, ServerPrepare,
 };
 pub use server_ready::ServerReady;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use prepare_behave::effect_traits::{
 };
 pub use server_prepare::{
     BindServe, ConfigureServerEffect, LoggerInitialization, PrepareError, PrepareStartError,
-    ServeAddress, ServerPrepare,
+    ServeAddress, ServerPrepare,PrepareDecorator
 };
 pub use server_ready::ServerReady;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,16 +18,16 @@ pub use prepare_behave::effect_traits::{
     FalliblePrepare, Prepare, PrepareMiddlewareEffect, PrepareRouteEffect, PrepareStateEffect,
 };
 pub use server_prepare::{
-    ConfigureServerEffect, LoggerInitialization, PrepareError, PrepareStartError, ServeAddress,
-    ServerPrepare,BindServe
+    BindServe, ConfigureServerEffect, LoggerInitialization, PrepareError, PrepareStartError,
+    ServeAddress, ServerPrepare,
 };
 pub use server_ready::ServerReady;
 
 pub use axum_starter_macro::{prepare, Configure, FromStateCollector, Provider};
 pub use config_provide::provider::Provider;
 pub use effect_utils::{router, state};
-pub use prepare_sets::{concurrent_set::ConcurrentPrepareSet, serial_set::SerialPrepareSet};
 pub use hyper::server::accept::Accept;
+pub use prepare_sets::{concurrent_set::ConcurrentPrepareSet, serial_set::SerialPrepareSet};
 
 pub use hyper::server::{conn::AddrIncoming, Builder};
 /// [`Prepare`](crate::Prepare) return type, helper for macro code gen

--- a/src/prepare_behave/effect_contain/prepare.rs
+++ b/src/prepare_behave/effect_contain/prepare.rs
@@ -1,25 +1,25 @@
+use std::future::IntoFuture;
 use std::sync::Arc;
 
 use http_body::Body;
+use tap::Pipe;
 use tower::layer::util::Stack;
-
-use crate::{
-    prepare_behave::traits::{
-        prepare_middleware::PrepareMiddlewareEffect, prepare_route::PrepareRouteEffect,
-        prepare_state::PrepareStateEffect, Prepare,
-    },
-    PrepareError,
-};
+use futures::TryFutureExt;
+use crate::{prepare_behave::traits::{
+    prepare_middleware::PrepareMiddlewareEffect, prepare_route::PrepareRouteEffect,
+    prepare_state::PrepareStateEffect, Prepare,
+}, PrepareDecorator, PrepareError};
 
 use super::EffectContainer;
 
 impl<R, L> EffectContainer<R, L> {
-    pub(crate) async fn then_route<S, B, C, P>(
+    pub(crate) async fn then_route<D,S, B, C, P>(
         self,
         prepare: P,
         configure: Arc<C>,
     ) -> Result<EffectContainer<(P::Effect, R), L>, PrepareError>
     where
+    D:PrepareDecorator,
         C: 'static,
         P: Prepare<C>,
         B: Body + 'static + Send,
@@ -29,17 +29,21 @@ impl<R, L> EffectContainer<R, L> {
         Ok(self.set_route(
             prepare
                 .prepare(configure)
+                .into_future()
+                .map_err(|err| PrepareError::to_prepare_error::<P, _>(err))
+                .pipe(D::decorator)
                 .await
-                .map_err(|err| PrepareError::to_prepare_error::<P, _>(err))?,
+                ?,
         ))
     }
 
-    pub(crate) async fn then_state<C, P>(
+    pub(crate) async fn then_state<D,C, P>(
         self,
         prepare: P,
         configure: Arc<C>,
     ) -> Result<Self, PrepareError>
     where
+        D:PrepareDecorator,
         C: 'static,
         P: Prepare<C>,
         P::Effect: PrepareStateEffect,
@@ -47,12 +51,15 @@ impl<R, L> EffectContainer<R, L> {
         Ok(self.set_state(
             prepare
                 .prepare(configure)
+                .into_future()
+                .map_err(PrepareError::to_prepare_error::<P, _>)
+                .pipe(D::decorator)
                 .await
-                .map_err(PrepareError::to_prepare_error::<P, _>)?,
+                ?,
         ))
     }
 
-    pub(crate) async fn then_middleware<S, C, P>(
+    pub(crate) async fn then_middleware<D,S, C, P>(
         self,
         prepare: P,
         configure: Arc<C>,
@@ -61,6 +68,7 @@ impl<R, L> EffectContainer<R, L> {
         PrepareError,
     >
     where
+        D:PrepareDecorator,
         C: 'static,
         P: Prepare<C>,
         P::Effect: PrepareMiddlewareEffect<S>,
@@ -68,8 +76,11 @@ impl<R, L> EffectContainer<R, L> {
         Ok(self.set_middleware(
             prepare
                 .prepare(configure)
+                .into_future()
+                .map_err(PrepareError::to_prepare_error::<P, _>)
+                .pipe(D::decorator)
                 .await
-                .map_err(PrepareError::to_prepare_error::<P, _>)?,
+                ?,
         ))
     }
 }

--- a/src/prepare_behave/effect_contain/prepare.rs
+++ b/src/prepare_behave/effect_contain/prepare.rs
@@ -1,25 +1,28 @@
 use std::future::IntoFuture;
 use std::sync::Arc;
 
+use crate::{
+    prepare_behave::traits::{
+        prepare_middleware::PrepareMiddlewareEffect, prepare_route::PrepareRouteEffect,
+        prepare_state::PrepareStateEffect, Prepare,
+    },
+    PrepareDecorator, PrepareError,
+};
+use futures::TryFutureExt;
 use http_body::Body;
 use tap::Pipe;
 use tower::layer::util::Stack;
-use futures::TryFutureExt;
-use crate::{prepare_behave::traits::{
-    prepare_middleware::PrepareMiddlewareEffect, prepare_route::PrepareRouteEffect,
-    prepare_state::PrepareStateEffect, Prepare,
-}, PrepareDecorator, PrepareError};
 
 use super::EffectContainer;
 
 impl<R, L> EffectContainer<R, L> {
-    pub(crate) async fn then_route<D,S, B, C, P>(
+    pub(crate) async fn then_route<D, S, B, C, P>(
         self,
         prepare: P,
         configure: Arc<C>,
     ) -> Result<EffectContainer<(P::Effect, R), L>, PrepareError>
     where
-    D:PrepareDecorator,
+        D: PrepareDecorator,
         C: 'static,
         P: Prepare<C>,
         B: Body + 'static + Send,
@@ -32,18 +35,17 @@ impl<R, L> EffectContainer<R, L> {
                 .into_future()
                 .map_err(|err| PrepareError::to_prepare_error::<P, _>(err))
                 .pipe(D::decorator)
-                .await
-                ?,
+                .await?,
         ))
     }
 
-    pub(crate) async fn then_state<D,C, P>(
+    pub(crate) async fn then_state<D, C, P>(
         self,
         prepare: P,
         configure: Arc<C>,
     ) -> Result<Self, PrepareError>
     where
-        D:PrepareDecorator,
+        D: PrepareDecorator,
         C: 'static,
         P: Prepare<C>,
         P::Effect: PrepareStateEffect,
@@ -54,12 +56,11 @@ impl<R, L> EffectContainer<R, L> {
                 .into_future()
                 .map_err(PrepareError::to_prepare_error::<P, _>)
                 .pipe(D::decorator)
-                .await
-                ?,
+                .await?,
         ))
     }
 
-    pub(crate) async fn then_middleware<D,S, C, P>(
+    pub(crate) async fn then_middleware<D, S, C, P>(
         self,
         prepare: P,
         configure: Arc<C>,
@@ -68,7 +69,7 @@ impl<R, L> EffectContainer<R, L> {
         PrepareError,
     >
     where
-        D:PrepareDecorator,
+        D: PrepareDecorator,
         C: 'static,
         P: Prepare<C>,
         P::Effect: PrepareMiddlewareEffect<S>,
@@ -79,8 +80,7 @@ impl<R, L> EffectContainer<R, L> {
                 .into_future()
                 .map_err(PrepareError::to_prepare_error::<P, _>)
                 .pipe(D::decorator)
-                .await
-                ?,
+                .await?,
         ))
     }
 }

--- a/src/prepare_sets/concurrent_set.rs
+++ b/src/prepare_sets/concurrent_set.rs
@@ -1,11 +1,13 @@
+use std::{future::IntoFuture, sync::Arc};
 #[allow(unused_imports)]
 use std::any::type_name;
-use std::{future::IntoFuture, sync::Arc};
+use std::marker::PhantomData;
 
 use futures::{
     future::{join, ok},
     FutureExt, TryFutureExt,
 };
+use tap::Pipe;
 
 use crate::{
     prepare_behave::{
@@ -14,6 +16,7 @@ use crate::{
     },
     PrepareError,
 };
+use crate::server_prepare::PrepareDecorator;
 
 use super::{BoxFuture, StateContainerFuture, StateContainerResult};
 
@@ -21,29 +24,31 @@ use super::{BoxFuture, StateContainerFuture, StateContainerResult};
 ///
 /// ## Note
 /// the sync part of [Prepare] will be run immediately
-pub struct ConcurrentPrepareSet<C, T = StateContainerResult> {
+pub struct ConcurrentPrepareSet<C, Decorator, T = StateContainerResult> {
     prepare_fut: BoxFuture<T>,
     configure: Arc<C>,
+    __phantom_decorator: PhantomData<Decorator>,
 }
 
-impl<C> ConcurrentPrepareSet<C> {
+impl<C, Decorator> ConcurrentPrepareSet<C, Decorator> {
     /// get the [Future]
     pub(crate) fn into_internal_future(self) -> StateContainerFuture {
         self.prepare_fut
     }
 }
 
-impl<C> ConcurrentPrepareSet<C>
-where
-    C: 'static,
+impl<C, Decorator> ConcurrentPrepareSet<C, Decorator>
+    where
+        C: 'static,
+        Decorator: PrepareDecorator
 {
     /// join a [Prepare] into concurrent execute set
     ///
     /// concurrent only support state prepare
-    pub fn join_state<P>(self, prepare: P) -> ConcurrentPrepareSet<C>
-    where
-        P: Prepare<C> + 'static,
-        P::Effect: PrepareStateEffect,
+    pub fn join_state<P>(self, prepare: P) -> ConcurrentPrepareSet<C, Decorator>
+        where
+            P: Prepare<C> + 'static,
+            P::Effect: PrepareStateEffect,
     {
         debug!(
             mode = "concurrently",
@@ -59,27 +64,29 @@ where
                 .into_future()
                 .map_err(PrepareError::to_prepare_error::<P, _>),
         )
-        .map(|(l, r)| {
-            Ok({
-                let mut states = l?;
-                let effect = r?;
-                effect.take_state(&mut states);
+            .map(|(l, r)| {
+                Ok({
+                    let mut states = l?;
+                    let effect = r?;
+                    effect.take_state(&mut states);
 
-                states
+                    states
+                })
             })
-        })
-        .boxed_local();
+            .pipe(Decorator::decorator)
+            .boxed_local();
 
         ConcurrentPrepareSet {
             prepare_fut,
             configure: self.configure,
+            __phantom_decorator: PhantomData,
         }
     }
 
     /// join a [Prepare] without effect
-    pub fn join<P>(self, prepare: P) -> ConcurrentPrepareSet<C>
-    where
-        P: Prepare<C, Effect = ()> + 'static,
+    pub fn join<P>(self, prepare: P) -> ConcurrentPrepareSet<C, Decorator>
+        where
+            P: Prepare<C, Effect=()> + 'static,
     {
         debug!(
             mode = "concurrently",
@@ -95,24 +102,27 @@ where
                 .into_future()
                 .map_err(PrepareError::to_prepare_error::<P, _>),
         )
-        .map(|(l, r)| {
-            r?;
-            l
-        })
-        .boxed_local();
+            .map(|(l, r)| {
+                r?;
+                l
+            })
+            .pipe(Decorator::decorator)
+            .boxed_local();
 
         ConcurrentPrepareSet {
             prepare_fut,
             configure: self.configure,
+            __phantom_decorator: PhantomData,
         }
     }
 }
 
-impl<C: 'static> ConcurrentPrepareSet<C> {
+impl<C: 'static, Decorator> ConcurrentPrepareSet<C, Decorator> {
     pub(crate) fn new(configure: Arc<C>) -> Self {
         Self {
             prepare_fut: ok(StateCollector::new()).boxed_local(),
             configure,
+            __phantom_decorator: PhantomData,
         }
     }
 }

--- a/src/prepare_sets/concurrent_set.rs
+++ b/src/prepare_sets/concurrent_set.rs
@@ -62,7 +62,8 @@ impl<C, Decorator> ConcurrentPrepareSet<C, Decorator>
             prepare
                 .prepare(configure)
                 .into_future()
-                .map_err(PrepareError::to_prepare_error::<P, _>),
+                .map_err(PrepareError::to_prepare_error::<P, _>)
+                .pipe(Decorator::decorator)
         )
             .map(|(l, r)| {
                 Ok({
@@ -73,7 +74,7 @@ impl<C, Decorator> ConcurrentPrepareSet<C, Decorator>
                     states
                 })
             })
-            .pipe(Decorator::decorator)
+
             .boxed_local();
 
         ConcurrentPrepareSet {
@@ -100,13 +101,14 @@ impl<C, Decorator> ConcurrentPrepareSet<C, Decorator>
             prepare
                 .prepare(configure)
                 .into_future()
-                .map_err(PrepareError::to_prepare_error::<P, _>),
+                .map_err(PrepareError::to_prepare_error::<P, _>)
+                .pipe(Decorator::decorator),
         )
             .map(|(l, r)| {
                 r?;
                 l
             })
-            .pipe(Decorator::decorator)
+
             .boxed_local();
 
         ConcurrentPrepareSet {

--- a/src/server_prepare/adding_middleware.rs
+++ b/src/server_prepare/adding_middleware.rs
@@ -2,14 +2,16 @@ use tower::layer::util::Stack;
 
 use crate::{prepare_sets::ContainerResult, ServerPrepare};
 
-impl<C: 'static, Log, State, Graceful, R: 'static, L: 'static>
-    ServerPrepare<C, ContainerResult<R, L>, Log, State, Graceful>
+type MiddlewareLayerRet<C, R, M, L, Log, State, Graceful, Decorator> = ServerPrepare<C, ContainerResult<R, Stack<M, L>>, Log, State, Graceful, Decorator>;
+
+impl<C: 'static, Log, State, Graceful, R: 'static, L: 'static, Decorator>
+ServerPrepare<C, ContainerResult<R, L>, Log, State, Graceful, Decorator>
 {
     /// adding middleware without previously [Prepare](crate::Prepare) action
     pub fn layer<M: 'static>(
         self,
         middleware: M,
-    ) -> ServerPrepare<C, ContainerResult<R, Stack<M, L>>, Log, State, Graceful> {
+    ) -> MiddlewareLayerRet<C, R, M, L, Log, State, Graceful, Decorator> {
         self.span.in_scope(|| {
             debug!(middleware.layer = core::any::type_name::<M>());
         });

--- a/src/server_prepare/adding_middleware.rs
+++ b/src/server_prepare/adding_middleware.rs
@@ -1,11 +1,13 @@
 use tower::layer::util::Stack;
 
 use crate::{prepare_sets::ContainerResult, ServerPrepare};
+use crate::server_prepare::PrepareDecorator;
 
 type MiddlewareLayerRet<C, R, M, L, Log, State, Graceful, Decorator> = ServerPrepare<C, ContainerResult<R, Stack<M, L>>, Log, State, Graceful, Decorator>;
 
 impl<C: 'static, Log, State, Graceful, R: 'static, L: 'static, Decorator>
 ServerPrepare<C, ContainerResult<R, L>, Log, State, Graceful, Decorator>
+where Decorator:PrepareDecorator
 {
     /// adding middleware without previously [Prepare](crate::Prepare) action
     pub fn layer<M: 'static>(

--- a/src/server_prepare/adding_middleware.rs
+++ b/src/server_prepare/adding_middleware.rs
@@ -1,13 +1,15 @@
 use tower::layer::util::Stack;
 
-use crate::{prepare_sets::ContainerResult, ServerPrepare};
 use crate::server_prepare::PrepareDecorator;
+use crate::{prepare_sets::ContainerResult, ServerPrepare};
 
-type MiddlewareLayerRet<C, R, M, L, Log, State, Graceful, Decorator> = ServerPrepare<C, ContainerResult<R, Stack<M, L>>, Log, State, Graceful, Decorator>;
+type MiddlewareLayerRet<C, R, M, L, Log, State, Graceful, Decorator> =
+    ServerPrepare<C, ContainerResult<R, Stack<M, L>>, Log, State, Graceful, Decorator>;
 
 impl<C: 'static, Log, State, Graceful, R: 'static, L: 'static, Decorator>
-ServerPrepare<C, ContainerResult<R, L>, Log, State, Graceful, Decorator>
-where Decorator:PrepareDecorator
+    ServerPrepare<C, ContainerResult<R, L>, Log, State, Graceful, Decorator>
+where
+    Decorator: PrepareDecorator,
 {
     /// adding middleware without previously [Prepare](crate::Prepare) action
     pub fn layer<M: 'static>(

--- a/src/server_prepare/adding_prepare.rs
+++ b/src/server_prepare/adding_prepare.rs
@@ -1,5 +1,6 @@
 use tower::layer::util::Stack;
 
+use crate::server_prepare::PrepareDecorator;
 use crate::{
     prepare_behave::effect_traits::{
         Prepare, PrepareMiddlewareEffect, PrepareRouteEffect, PrepareStateEffect,
@@ -7,12 +8,17 @@ use crate::{
     prepare_sets::ContainerResult,
     ConcurrentPrepareSet, ServerPrepare,
 };
-use crate::server_prepare::PrepareDecorator;
 
-type ServerPrepareNestRoute<C, P, Ri, Li, Log, State, Graceful,Decorator> =
-    ServerPrepare<C, ContainerResult<(<P as Prepare<C>>::Effect, Ri), Li>, Log, State, Graceful,Decorator>;
+type ServerPrepareNestRoute<C, P, Ri, Li, Log, State, Graceful, Decorator> = ServerPrepare<
+    C,
+    ContainerResult<(<P as Prepare<C>>::Effect, Ri), Li>,
+    Log,
+    State,
+    Graceful,
+    Decorator,
+>;
 
-type ServerPrepareNestMiddleware<C, P, Ri, Li, S, Log, State, Graceful,Decorator> = ServerPrepare<
+type ServerPrepareNestMiddleware<C, P, Ri, Li, S, Log, State, Graceful, Decorator> = ServerPrepare<
     C,
     ContainerResult<
         Ri,
@@ -20,13 +26,14 @@ type ServerPrepareNestMiddleware<C, P, Ri, Li, S, Log, State, Graceful,Decorator
     >,
     Log,
     State,
-    Graceful,Decorator
+    Graceful,
+    Decorator,
 >;
 
-impl<C: 'static, Log, State, Graceful, Ri: 'static, Li: 'static,Decorator>
-    ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful,Decorator>
-
-where Decorator:PrepareDecorator
+impl<C: 'static, Log, State, Graceful, Ri: 'static, Li: 'static, Decorator>
+    ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful, Decorator>
+where
+    Decorator: PrepareDecorator,
 {
     /// adding a set of [Prepare] executing concurrently
     ///
@@ -36,9 +43,10 @@ where Decorator:PrepareDecorator
     pub fn prepare_concurrent<F>(
         self,
         concurrent: F,
-    ) -> ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful,Decorator>
+    ) -> ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful, Decorator>
     where
-        F: FnOnce(ConcurrentPrepareSet<C,Decorator>) -> ConcurrentPrepareSet<C,Decorator> + 'static,
+        F: FnOnce(ConcurrentPrepareSet<C, Decorator>) -> ConcurrentPrepareSet<C, Decorator>
+            + 'static,
     {
         let prepares = self.span.in_scope(|| {
             debug!(mode = "Concurrent", action = "Add Prepare");
@@ -58,7 +66,7 @@ where Decorator:PrepareDecorator
     pub fn prepare_route<P, B, S>(
         self,
         prepare: P,
-    ) -> ServerPrepareNestRoute<C, P, Ri, Li, Log, State, Graceful,Decorator>
+    ) -> ServerPrepareNestRoute<C, P, Ri, Li, Log, State, Graceful, Decorator>
     where
         P: Prepare<C> + 'static,
         P::Effect: PrepareRouteEffect<S, B>,
@@ -87,7 +95,7 @@ where Decorator:PrepareDecorator
     pub fn prepare_state<P>(
         self,
         prepare: P,
-    ) -> ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful,Decorator>
+    ) -> ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful, Decorator>
     where
         P: Prepare<C> + 'static,
         P::Effect: PrepareStateEffect,
@@ -114,7 +122,7 @@ where Decorator:PrepareDecorator
     pub fn prepare_middleware<S, P>(
         self,
         prepare: P,
-    ) -> ServerPrepareNestMiddleware<C, P, Ri, Li, S, Log, State, Graceful,Decorator>
+    ) -> ServerPrepareNestMiddleware<C, P, Ri, Li, S, Log, State, Graceful, Decorator>
     where
         S: 'static,
         P: Prepare<C> + 'static,
@@ -136,7 +144,7 @@ where Decorator:PrepareDecorator
     pub fn prepare<P>(
         self,
         prepare: P,
-    ) -> ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful,Decorator>
+    ) -> ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful, Decorator>
     where
         P: Prepare<C, Effect = ()> + 'static,
     {

--- a/src/server_prepare/adding_prepare.rs
+++ b/src/server_prepare/adding_prepare.rs
@@ -8,10 +8,10 @@ use crate::{
     ConcurrentPrepareSet, ServerPrepare,
 };
 
-type ServerPrepareNestRoute<C, P, Ri, Li, Log, State, Graceful> =
-    ServerPrepare<C, ContainerResult<(<P as Prepare<C>>::Effect, Ri), Li>, Log, State, Graceful>;
+type ServerPrepareNestRoute<C, P, Ri, Li, Log, State, Graceful,Decorator> =
+    ServerPrepare<C, ContainerResult<(<P as Prepare<C>>::Effect, Ri), Li>, Log, State, Graceful,Decorator>;
 
-type ServerPrepareNestMiddleware<C, P, Ri, Li, S, Log, State, Graceful> = ServerPrepare<
+type ServerPrepareNestMiddleware<C, P, Ri, Li, S, Log, State, Graceful,Decorator> = ServerPrepare<
     C,
     ContainerResult<
         Ri,
@@ -19,11 +19,11 @@ type ServerPrepareNestMiddleware<C, P, Ri, Li, S, Log, State, Graceful> = Server
     >,
     Log,
     State,
-    Graceful,
+    Graceful,Decorator
 >;
 
-impl<C: 'static, Log, State, Graceful, Ri: 'static, Li: 'static>
-    ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful>
+impl<C: 'static, Log, State, Graceful, Ri: 'static, Li: 'static,Decorator>
+    ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful,Decorator>
 {
     /// adding a set of [Prepare] executing concurrently
     ///
@@ -33,7 +33,7 @@ impl<C: 'static, Log, State, Graceful, Ri: 'static, Li: 'static>
     pub fn prepare_concurrent<F>(
         self,
         concurrent: F,
-    ) -> ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful>
+    ) -> ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful,Decorator>
     where
         F: FnOnce(ConcurrentPrepareSet<C>) -> ConcurrentPrepareSet<C> + 'static,
     {
@@ -55,7 +55,7 @@ impl<C: 'static, Log, State, Graceful, Ri: 'static, Li: 'static>
     pub fn prepare_route<P, B, S>(
         self,
         prepare: P,
-    ) -> ServerPrepareNestRoute<C, P, Ri, Li, Log, State, Graceful>
+    ) -> ServerPrepareNestRoute<C, P, Ri, Li, Log, State, Graceful,Decorator>
     where
         P: Prepare<C> + 'static,
         P::Effect: PrepareRouteEffect<S, B>,
@@ -84,7 +84,7 @@ impl<C: 'static, Log, State, Graceful, Ri: 'static, Li: 'static>
     pub fn prepare_state<P>(
         self,
         prepare: P,
-    ) -> ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful>
+    ) -> ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful,Decorator>
     where
         P: Prepare<C> + 'static,
         P::Effect: PrepareStateEffect,
@@ -111,7 +111,7 @@ impl<C: 'static, Log, State, Graceful, Ri: 'static, Li: 'static>
     pub fn prepare_middleware<S, P>(
         self,
         prepare: P,
-    ) -> ServerPrepareNestMiddleware<C, P, Ri, Li, S, Log, State, Graceful>
+    ) -> ServerPrepareNestMiddleware<C, P, Ri, Li, S, Log, State, Graceful,Decorator>
     where
         S: 'static,
         P: Prepare<C> + 'static,
@@ -133,7 +133,7 @@ impl<C: 'static, Log, State, Graceful, Ri: 'static, Li: 'static>
     pub fn prepare<P>(
         self,
         prepare: P,
-    ) -> ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful>
+    ) -> ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful,Decorator>
     where
         P: Prepare<C, Effect = ()> + 'static,
     {

--- a/src/server_prepare/adding_prepare.rs
+++ b/src/server_prepare/adding_prepare.rs
@@ -7,6 +7,7 @@ use crate::{
     prepare_sets::ContainerResult,
     ConcurrentPrepareSet, ServerPrepare,
 };
+use crate::server_prepare::PrepareDecorator;
 
 type ServerPrepareNestRoute<C, P, Ri, Li, Log, State, Graceful,Decorator> =
     ServerPrepare<C, ContainerResult<(<P as Prepare<C>>::Effect, Ri), Li>, Log, State, Graceful,Decorator>;
@@ -24,6 +25,8 @@ type ServerPrepareNestMiddleware<C, P, Ri, Li, S, Log, State, Graceful,Decorator
 
 impl<C: 'static, Log, State, Graceful, Ri: 'static, Li: 'static,Decorator>
     ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful,Decorator>
+
+where Decorator:PrepareDecorator
 {
     /// adding a set of [Prepare] executing concurrently
     ///
@@ -35,7 +38,7 @@ impl<C: 'static, Log, State, Graceful, Ri: 'static, Li: 'static,Decorator>
         concurrent: F,
     ) -> ServerPrepare<C, ContainerResult<Ri, Li>, Log, State, Graceful,Decorator>
     where
-        F: FnOnce(ConcurrentPrepareSet<C>) -> ConcurrentPrepareSet<C> + 'static,
+        F: FnOnce(ConcurrentPrepareSet<C,Decorator>) -> ConcurrentPrepareSet<C,Decorator> + 'static,
     {
         let prepares = self.span.in_scope(|| {
             debug!(mode = "Concurrent", action = "Add Prepare");

--- a/src/server_prepare/configure.rs
+++ b/src/server_prepare/configure.rs
@@ -81,9 +81,6 @@ where
 /// add decorator for each prepare 's [`Future`]
 ///
 ///It is useful for adding extra functional on original prepare task
-///
-///## NOTE
-///this feature is **NOT** available yet
 pub trait PrepareDecorator: 'static {
     type OutFut<'fut, Fut, T>: Future<Output = Result<T, PrepareError>> + 'fut
     where

--- a/src/server_prepare/configure.rs
+++ b/src/server_prepare/configure.rs
@@ -2,10 +2,10 @@ use std::error;
 use std::fmt::Display;
 use std::net::SocketAddr;
 
-use hyper::Server;
 use hyper::server::accept::Accept;
-use hyper::server::Builder;
 use hyper::server::conn::AddrIncoming;
+use hyper::server::Builder;
+use hyper::Server;
 
 /// binding to any kind of income stream
 ///
@@ -38,7 +38,10 @@ pub trait ServeAddress {
     fn get_address(&self) -> Self::Address;
 }
 
-impl<T> BindServe for T where T: ServeAddress {
+impl<T> BindServe for T
+where
+    T: ServeAddress,
+{
     type A = AddrIncoming;
     type Target = SocketAddr;
 
@@ -48,8 +51,7 @@ impl<T> BindServe for T where T: ServeAddress {
 
     fn create_listener(&self) -> Self::A {
         let addr = &self.get_address().into();
-        AddrIncoming::bind(addr)
-            .unwrap_or_else(|e| panic!("error bind to {addr} {e}"))
+        AddrIncoming::bind(addr).unwrap_or_else(|e| panic!("error bind to {addr} {e}"))
     }
 }
 
@@ -65,11 +67,10 @@ pub trait LoggerInitialization {
 
 /// change the server configure
 pub trait ConfigureServerEffect<A = AddrIncoming>
-    where A: Accept {
-    fn effect_server(
-        &self,
-        server: Builder<A>,
-    ) -> Builder<A> {
+where
+    A: Accept,
+{
+    fn effect_server(&self, server: Builder<A>) -> Builder<A> {
         server
     }
 }

--- a/src/server_prepare/configure.rs
+++ b/src/server_prepare/configure.rs
@@ -3,10 +3,10 @@ use std::fmt::Display;
 use std::future::Future;
 use std::net::SocketAddr;
 
-use hyper::Server;
 use hyper::server::accept::Accept;
-use hyper::server::Builder;
 use hyper::server::conn::AddrIncoming;
+use hyper::server::Builder;
+use hyper::Server;
 
 use crate::PrepareError;
 
@@ -42,8 +42,8 @@ pub trait ServeAddress {
 }
 
 impl<T> BindServe for T
-    where
-        T: ServeAddress,
+where
+    T: ServeAddress,
 {
     type A = AddrIncoming;
     type Target = SocketAddr;
@@ -70,8 +70,8 @@ pub trait LoggerInitialization {
 
 /// change the server configure
 pub trait ConfigureServerEffect<A = AddrIncoming>
-    where
-        A: Accept,
+where
+    A: Accept,
 {
     fn effect_server(&self, server: Builder<A>) -> Builder<A> {
         server
@@ -84,16 +84,16 @@ pub trait ConfigureServerEffect<A = AddrIncoming>
 ///
 ///## NOTE
 ///this feature is **NOT** available yet
-pub trait PrepareDecorator :'static{
-    type OutFut<'fut, Fut, T>: Future<Output=Result<T, PrepareError>> + 'fut
-        where Fut: Future<Output=Result<T, PrepareError>> + 'fut ,
-              T: 'static
-    ;
+pub trait PrepareDecorator: 'static {
+    type OutFut<'fut, Fut, T>: Future<Output = Result<T, PrepareError>> + 'fut
+    where
+        Fut: Future<Output = Result<T, PrepareError>> + 'fut,
+        T: 'static;
 
     fn decorator<'fut, Fut, T>(in_fut: Fut) -> Self::OutFut<'fut, Fut, T>
-        where Fut: Future<Output=Result<T, PrepareError>> + 'fut ,
-              T: 'static
-    ;
+    where
+        Fut: Future<Output = Result<T, PrepareError>> + 'fut,
+        T: 'static;
 }
 
 /// Default Decorator without any effect
@@ -104,8 +104,10 @@ impl PrepareDecorator for EmptyDecorator {
         where Fut: Future<Output=Result<T, PrepareError>> + 'fut  ,T: 'static;
 
     fn decorator<'fut, Fut, T>(in_fut: Fut) -> Self::OutFut<'fut, Fut, T>
-        where Fut: Future<Output=Result<T, PrepareError>> + 'fut , T: 'static {
+    where
+        Fut: Future<Output = Result<T, PrepareError>> + 'fut,
+        T: 'static,
+    {
         in_fut
     }
 }
-

--- a/src/server_prepare/configure.rs
+++ b/src/server_prepare/configure.rs
@@ -1,11 +1,56 @@
 use std::error;
+use std::fmt::Display;
+use std::net::SocketAddr;
 
+use hyper::Server;
+use hyper::server::accept::Accept;
+use hyper::server::Builder;
 use hyper::server::conn::AddrIncoming;
+
+/// binding to any kind of income stream
+///
+/// ## Using Cases
+/// 1. Accept Data Stream from other source.
+/// For example from UDS, Pipe or even Files
+/// 2. Adding extra functional on exist [`Accept`] type.
+/// For example adding logging request ip address on [`AddrIncoming`]
+pub trait BindServe {
+    /// the Accept type
+    type A: Accept;
+    /// the listen source for logger
+    type Target: Display;
+
+    /// get where the binder listen for
+    fn listen_target(&self) -> Self::Target;
+
+    /// create listener, ready for listen incoming streams
+    fn create_listener(&self) -> Self::A;
+
+    /// bind to listen target
+    fn bind(&self) -> Builder<Self::A> {
+        Server::builder(self.create_listener())
+    }
+}
 
 /// get the address this server are going to bind with
 pub trait ServeAddress {
-    type Address: Into<std::net::SocketAddr>;
+    type Address: Into<SocketAddr>;
     fn get_address(&self) -> Self::Address;
+}
+
+impl<T> BindServe for T where T: ServeAddress {
+    type A = AddrIncoming;
+    type Target = SocketAddr;
+
+    fn listen_target(&self) -> Self::Target {
+        self.get_address().into()
+    }
+
+    fn create_listener(&self) -> Self::A {
+        let addr = &self.get_address().into();
+        AddrIncoming::bind(addr)
+            .unwrap_or_else(|e| panic!("error bind to {addr} {e}"))
+    }
 }
 
 /// init the logger of this server by the Config
@@ -19,11 +64,12 @@ pub trait LoggerInitialization {
 }
 
 /// change the server configure
-pub trait ConfigureServerEffect {
+pub trait ConfigureServerEffect<A = AddrIncoming>
+    where A: Accept {
     fn effect_server(
         &self,
-        server: hyper::server::Builder<AddrIncoming>,
-    ) -> hyper::server::Builder<AddrIncoming> {
+        server: Builder<A>,
+    ) -> Builder<A> {
         server
     }
 }

--- a/src/server_prepare/configure.rs
+++ b/src/server_prepare/configure.rs
@@ -84,7 +84,7 @@ pub trait ConfigureServerEffect<A = AddrIncoming>
 ///
 ///## NOTE
 ///this feature is **NOT** available yet
-pub trait PrepareDecorator {
+pub trait PrepareDecorator :'static{
     type OutFut<'fut, Fut, T>: Future<Output=Result<T, PrepareError>> + 'fut
         where Fut: Future<Output=Result<T, PrepareError>> + 'fut ,
               T: 'static

--- a/src/server_prepare/decorator.rs
+++ b/src/server_prepare/decorator.rs
@@ -1,0 +1,14 @@
+use crate::server_prepare::PrepareDecorator;
+use crate::ServerPrepare;
+
+impl<C, Effect, Log , State , Graceful ,Decorator> ServerPrepare<C, Effect, Log, State, Graceful, Decorator> {
+    /// Add Decorator apply on every prepare [`futures::Future`]
+    ///
+    /// this will overwrite old [`PrepareDecorator`], combine multiply [`PrepareDecorator`] is **Not**
+    ///support. Manual writing combining code instead
+    pub fn set_decorator<D>(self,_:D)->ServerPrepare<C, Effect, Log, State, Graceful, D>
+    where D:PrepareDecorator
+    {
+        ServerPrepare::new(self.prepares.change_decorator(),self.graceful,self.span)
+    }
+}

--- a/src/server_prepare/decorator.rs
+++ b/src/server_prepare/decorator.rs
@@ -1,14 +1,17 @@
 use crate::server_prepare::PrepareDecorator;
 use crate::ServerPrepare;
 
-impl<C, Effect, Log , State , Graceful ,Decorator> ServerPrepare<C, Effect, Log, State, Graceful, Decorator> {
+impl<C, Effect, Log, State, Graceful, Decorator>
+    ServerPrepare<C, Effect, Log, State, Graceful, Decorator>
+{
     /// Add Decorator apply on every prepare [`futures::Future`]
     ///
     /// this will overwrite old [`PrepareDecorator`], combine multiply [`PrepareDecorator`] is **Not**
     ///support. Manual writing combining code instead
-    pub fn set_decorator<D>(self,_:D)->ServerPrepare<C, Effect, Log, State, Graceful, D>
-    where D:PrepareDecorator
+    pub fn set_decorator<D>(self, _: D) -> ServerPrepare<C, Effect, Log, State, Graceful, D>
+    where
+        D: PrepareDecorator,
     {
-        ServerPrepare::new(self.prepares.change_decorator(),self.graceful,self.span)
+        ServerPrepare::new(self.prepares.change_decorator(), self.graceful, self.span)
     }
 }

--- a/src/server_prepare/error.rs
+++ b/src/server_prepare/error.rs
@@ -1,13 +1,20 @@
 use std::{any::type_name, error};
+use std::fmt::{Debug, Display, Formatter};
 
 use crate::prepare_behave::effect_collectors::state_collector::TypeNotInState;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(thiserror::Error)]
 /// the error while prepare for each [Prepare](crate::Prepare) task
 #[error("prepare error on {ty} : {source}")]
 pub struct PrepareError {
     ty: &'static str,
     source: Box<dyn error::Error>,
+}
+
+impl Debug for PrepareError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        <PrepareError as Display>::fmt(self,f)
+    }
 }
 
 impl PrepareError {

--- a/src/server_prepare/error.rs
+++ b/src/server_prepare/error.rs
@@ -1,5 +1,5 @@
-use std::{any::type_name, error};
 use std::fmt::{Debug, Display, Formatter};
+use std::{any::type_name, error};
 
 use crate::prepare_behave::effect_collectors::state_collector::TypeNotInState;
 
@@ -13,7 +13,7 @@ pub struct PrepareError {
 
 impl Debug for PrepareError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        <PrepareError as Display>::fmt(self,f)
+        <PrepareError as Display>::fmt(self, f)
     }
 }
 

--- a/src/server_prepare/graceful_shutdown.rs
+++ b/src/server_prepare/graceful_shutdown.rs
@@ -29,12 +29,14 @@ impl FetchGraceful for NoGraceful {
     }
 }
 
-impl<C, FutEffect, Log, State,Decorator> ServerPrepare<C, FutEffect, Log, State, NoGraceful,Decorator> {
+impl<C, FutEffect, Log, State, Decorator>
+    ServerPrepare<C, FutEffect, Log, State, NoGraceful, Decorator>
+{
     /// set the graceful shutdown signal
     pub fn graceful_shutdown<Fut>(
         self,
         future: Fut,
-    ) -> ServerPrepare<C, FutEffect, Log, State, Graceful<Fut>,Decorator>
+    ) -> ServerPrepare<C, FutEffect, Log, State, Graceful<Fut>, Decorator>
     where
         Fut: Future<Output = ()>,
     {

--- a/src/server_prepare/graceful_shutdown.rs
+++ b/src/server_prepare/graceful_shutdown.rs
@@ -29,12 +29,12 @@ impl FetchGraceful for NoGraceful {
     }
 }
 
-impl<C, FutEffect, Log, State> ServerPrepare<C, FutEffect, Log, State, NoGraceful> {
+impl<C, FutEffect, Log, State,Decorator> ServerPrepare<C, FutEffect, Log, State, NoGraceful,Decorator> {
     /// set the graceful shutdown signal
     pub fn graceful_shutdown<Fut>(
         self,
         future: Fut,
-    ) -> ServerPrepare<C, FutEffect, Log, State, Graceful<Fut>>
+    ) -> ServerPrepare<C, FutEffect, Log, State, Graceful<Fut>,Decorator>
     where
         Fut: Future<Output = ()>,
     {

--- a/src/server_prepare/mod.rs
+++ b/src/server_prepare/mod.rs
@@ -1,24 +1,24 @@
+#[allow(unused_imports)]
+use std::any::type_name;
 use std::{
     convert::Infallible,
     marker::{PhantomData, Send},
     sync::Arc,
 };
-#[allow(unused_imports)]
-use std::any::type_name;
 
-use axum::{body::Bytes, BoxError, Router, routing::Route};
+use axum::{body::Bytes, routing::Route, BoxError, Router};
 use futures::Future;
-use hyper::{Body, Request, Response};
 use hyper::server::accept::Accept;
+use hyper::{Body, Request, Response};
 use tap::Pipe;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tower::{Layer, layer::util::Identity, Service, ServiceBuilder};
+use tower::{layer::util::Identity, Layer, Service, ServiceBuilder};
 
 use crate::{
     prepare_behave::{effect_traits::PrepareRouteEffect, FromStateCollector},
     prepare_sets::ContainerResult,
-    SerialPrepareSet,
     server_ready::ServerReady,
+    SerialPrepareSet,
 };
 
 pub use self::{
@@ -35,7 +35,6 @@ mod adding_prepare;
 mod error;
 mod graceful_shutdown;
 mod state_ready;
-
 
 mod configure;
 
@@ -71,8 +70,8 @@ impl<C, FutEffect, Log, State, Graceful> ServerPrepare<C, FutEffect, Log, State,
 }
 
 impl<C, FutEffect, State, Graceful> ServerPrepare<C, FutEffect, NoLog, State, Graceful>
-    where
-        C: LoggerInitialization,
+where
+    C: LoggerInitialization,
 {
     /// init the logger of this [ServerPrepare] ,require C impl [LoggerInitialization]
     pub fn init_logger(
@@ -90,18 +89,17 @@ impl<C, FutEffect, State, Graceful> ServerPrepare<C, FutEffect, NoLog, State, Gr
 
 impl<C: 'static> ServerPrepare<C, ContainerResult<(), Identity>, NoLog, StateNotReady, NoGraceful> {
     /// prepare staring the service with config
-    pub fn with_config(config: C) -> Self
-    {
+    pub fn with_config(config: C) -> Self {
         #[cfg(feature = "logger")]
-            let span = tracing::debug_span!("prepare server start");
+        let span = tracing::debug_span!("prepare server start");
         #[cfg(not(feature = "logger"))]
-            let span = crate::fake_span::FakeSpan;
+        let span = crate::fake_span::FakeSpan;
         ServerPrepare::new(SerialPrepareSet::new(Arc::new(config)), NoGraceful, span)
     }
 }
 
 impl<C: 'static, Log, State, Graceful, R, L>
-ServerPrepare<C, ContainerResult<R, L>, Log, StateReady<State>, Graceful>
+    ServerPrepare<C, ContainerResult<R, L>, Log, StateReady<State>, Graceful>
 {
     /// prepare to start this server
     ///
@@ -111,33 +109,34 @@ ServerPrepare<C, ContainerResult<R, L>, Log, StateReady<State>, Graceful>
         self,
     ) -> Result<
         ServerReady<
-            impl Future<Output=Result<(), hyper::Error>>,
-            impl Future<Output=Result<(), hyper::Error>>,
+            impl Future<Output = Result<(), hyper::Error>>,
+            impl Future<Output = Result<(), hyper::Error>>,
         >,
         PrepareStartError,
     >
-        where
+    where
         // config
-            C: BindServe + ConfigureServerEffect<<C as BindServe>::A>,
-            <C::A as Accept>::Conn: AsyncRead + AsyncWrite + Send + Sync + Unpin,
-            <C::A as Accept>::Error: Send + Sync + std::error::Error,
+        C: BindServe + ConfigureServerEffect<<C as BindServe>::A>,
+        <C::A as Accept>::Conn: AsyncRead + AsyncWrite + Send + Sync + Unpin,
+        <C::A as Accept>::Error: Send + Sync + std::error::Error,
         // middleware
-            L: Send + 'static,
-            ServiceBuilder<L>: Layer<Route> + Clone,
-            <ServiceBuilder<L> as Layer<Route>>::Service: Send
+        L: Send + 'static,
+        ServiceBuilder<L>: Layer<Route> + Clone,
+        <ServiceBuilder<L> as Layer<Route>>::Service: Send
             + Clone
-            + Service<Request<Body>, Response=Response<NewResBody>, Error=Infallible>
+            + Service<Request<Body>, Response = Response<NewResBody>, Error = Infallible>
             + 'static,
-            <<ServiceBuilder<L> as Layer<Route>>::Service as Service<Request<Body>>>::Future: Send,
-            NewResBody: http_body::Body<Data=Bytes> + Send + 'static,
-            NewResBody::Error: Into<BoxError>,
+        <<ServiceBuilder<L> as Layer<Route>>::Service as Service<Request<Body>>>::Future: Send,
+        NewResBody: http_body::Body<Data = Bytes> + Send + 'static,
+        NewResBody::Error: Into<BoxError>,
         // prepare task
-            R: PrepareRouteEffect<State, Body>,
+        R: PrepareRouteEffect<State, Body>,
         // state
-            State: FromStateCollector,
-            State: Clone + Send + 'static + Sync,
+        State: FromStateCollector,
+        State: Clone + Send + 'static + Sync,
         // graceful
-            Graceful: FetchGraceful, {
+        Graceful: FetchGraceful,
+    {
         self.preparing().await
     }
     /// prepare to start this server
@@ -147,33 +146,33 @@ ServerPrepare<C, ContainerResult<R, L>, Log, StateReady<State>, Graceful>
         self,
     ) -> Result<
         ServerReady<
-            impl Future<Output=Result<(), hyper::Error>>,
-            impl Future<Output=Result<(), hyper::Error>>,
+            impl Future<Output = Result<(), hyper::Error>>,
+            impl Future<Output = Result<(), hyper::Error>>,
         >,
         PrepareStartError,
     >
-        where
+    where
         // config
-            C: BindServe + ConfigureServerEffect<<C as BindServe>::A>,
-            <C::A as Accept>::Conn: AsyncRead + AsyncWrite + Send + Sync + Unpin,
-            <C::A as Accept>::Error: Send + Sync + std::error::Error,
+        C: BindServe + ConfigureServerEffect<<C as BindServe>::A>,
+        <C::A as Accept>::Conn: AsyncRead + AsyncWrite + Send + Sync + Unpin,
+        <C::A as Accept>::Error: Send + Sync + std::error::Error,
         // middleware
-            L: Send + 'static,
-            ServiceBuilder<L>: Layer<Route> + Clone,
-            <ServiceBuilder<L> as Layer<Route>>::Service: Send
+        L: Send + 'static,
+        ServiceBuilder<L>: Layer<Route> + Clone,
+        <ServiceBuilder<L> as Layer<Route>>::Service: Send
             + Clone
-            + Service<Request<Body>, Response=Response<NewResBody>, Error=Infallible>
+            + Service<Request<Body>, Response = Response<NewResBody>, Error = Infallible>
             + 'static,
-            <<ServiceBuilder<L> as Layer<Route>>::Service as Service<Request<Body>>>::Future: Send,
-            NewResBody: http_body::Body<Data=Bytes> + Send + 'static,
-            NewResBody::Error: Into<BoxError>,
+        <<ServiceBuilder<L> as Layer<Route>>::Service as Service<Request<Body>>>::Future: Send,
+        NewResBody: http_body::Body<Data = Bytes> + Send + 'static,
+        NewResBody::Error: Into<BoxError>,
         // prepare task
-            R: PrepareRouteEffect<State, Body>,
+        R: PrepareRouteEffect<State, Body>,
         // state
-            State: FromStateCollector,
-            State: Clone + Send + 'static + Sync,
+        State: FromStateCollector,
+        State: Clone + Send + 'static + Sync,
         // graceful
-            Graceful: FetchGraceful,
+        Graceful: FetchGraceful,
     {
         async {
             let (prepare_fut, configure) = self.prepares.unwrap();
@@ -195,7 +194,8 @@ ServerPrepare<C, ContainerResult<R, L>, Log, StateReady<State>, Graceful>
             let graceful = self.graceful.get_graceful();
 
             debug!(effect = "Server");
-            let server = configure.bind()
+            let server = configure
+                .bind()
                 // apply configure config server
                 .pipe(|server| configure.effect_server(server))
                 .serve(router.into_make_service());
@@ -211,16 +211,16 @@ ServerPrepare<C, ContainerResult<R, L>, Log, StateReady<State>, Graceful>
                 None => ServerReady::Server(server),
             })
         }
-            .pipe(|fut| {
-                #[cfg(feature = "logger")]
-                {
-                    tracing::Instrument::instrument(fut, self.span)
-                }
-                #[cfg(not(feature = "logger"))]
-                {
-                    fut
-                }
-            })
-            .await
+        .pipe(|fut| {
+            #[cfg(feature = "logger")]
+            {
+                tracing::Instrument::instrument(fut, self.span)
+            }
+            #[cfg(not(feature = "logger"))]
+            {
+                fut
+            }
+        })
+        .await
     }
 }

--- a/src/server_prepare/mod.rs
+++ b/src/server_prepare/mod.rs
@@ -20,10 +20,9 @@ use crate::{
     SerialPrepareSet,
     server_ready::ServerReady,
 };
-use crate::server_prepare::configure::{EmptyDecorator, PrepareDecorator};
 
 pub use self::{
-    configure::{BindServe, ConfigureServerEffect, LoggerInitialization, ServeAddress},
+    configure::{BindServe, ConfigureServerEffect, LoggerInitialization, ServeAddress,EmptyDecorator, PrepareDecorator},
     error::{PrepareError, PrepareStartError},
 };
 use self::{
@@ -45,18 +44,18 @@ pub struct LogInit;
 
 /// type for prepare starting
 pub struct ServerPrepare<C, Effect, Log = LogInit, State = StateNotReady, Graceful = NoGraceful, Decorator = EmptyDecorator> {
-    prepares: SerialPrepareSet<C, Effect>,
+    prepares: SerialPrepareSet<C, Effect,Decorator>,
     graceful: Graceful,
     #[cfg(feature = "logger")]
     span: tracing::Span,
     #[cfg(not(feature = "logger"))]
     span: crate::fake_span::FakeSpan,
-    _phantom: PhantomData<(Log, State, Decorator)>,
+    _phantom: PhantomData<(Log, State)>,
 }
 
 impl<C, FutEffect, Log, State, Graceful, Decorator> ServerPrepare<C, FutEffect, Log, State, Graceful, Decorator> {
     fn new(
-        prepares: SerialPrepareSet<C, FutEffect>,
+        prepares: SerialPrepareSet<C, FutEffect,Decorator>,
         graceful: Graceful,
         #[cfg(feature = "logger")] span: tracing::Span,
         #[cfg(not(feature = "logger"))] span: crate::fake_span::FakeSpan,
@@ -77,7 +76,7 @@ impl<C, FutEffect, State, Graceful, Decorator> ServerPrepare<C, FutEffect, NoLog
     /// init the logger of this [ServerPrepare] ,require C impl [LoggerInitialization]
     pub fn init_logger(
         self,
-    ) -> Result<ServerPrepare<C, FutEffect, LogInit, State, Graceful>, C::Error> {
+    ) -> Result<ServerPrepare<C, FutEffect, LogInit, State, Graceful,Decorator>, C::Error> {
         self.span.in_scope(|| {
             let t = self.prepares.get_ref_configure().init_logger();
             info!(logger = "Init");

--- a/src/server_prepare/mod.rs
+++ b/src/server_prepare/mod.rs
@@ -1,28 +1,31 @@
+#[allow(unused_imports)]
+use std::any::type_name;
 use std::{
     convert::Infallible,
     marker::{PhantomData, Send},
     sync::Arc,
 };
-#[allow(unused_imports)]
-use std::any::type_name;
 
-use axum::{body::Bytes, BoxError, Router, routing::Route};
+use axum::{body::Bytes, routing::Route, BoxError, Router};
 use futures::Future;
-use hyper::{Body, Request, Response};
 use hyper::server::accept::Accept;
+use hyper::{Body, Request, Response};
 use tap::Pipe;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tower::{Layer, layer::util::Identity, Service, ServiceBuilder};
+use tower::{layer::util::Identity, Layer, Service, ServiceBuilder};
 
 use crate::{
     prepare_behave::{effect_traits::PrepareRouteEffect, FromStateCollector},
     prepare_sets::ContainerResult,
-    SerialPrepareSet,
     server_ready::ServerReady,
+    SerialPrepareSet,
 };
 
 pub use self::{
-    configure::{BindServe, ConfigureServerEffect, LoggerInitialization, ServeAddress,EmptyDecorator, PrepareDecorator},
+    configure::{
+        BindServe, ConfigureServerEffect, EmptyDecorator, LoggerInitialization, PrepareDecorator,
+        ServeAddress,
+    },
     error::{PrepareError, PrepareStartError},
 };
 use self::{
@@ -44,8 +47,15 @@ pub struct NoLog;
 pub struct LogInit;
 
 /// type for prepare starting
-pub struct ServerPrepare<C, Effect, Log = LogInit, State = StateNotReady, Graceful = NoGraceful, Decorator = EmptyDecorator> {
-    prepares: SerialPrepareSet<C, Effect,Decorator>,
+pub struct ServerPrepare<
+    C,
+    Effect,
+    Log = LogInit,
+    State = StateNotReady,
+    Graceful = NoGraceful,
+    Decorator = EmptyDecorator,
+> {
+    prepares: SerialPrepareSet<C, Effect, Decorator>,
     graceful: Graceful,
     #[cfg(feature = "logger")]
     span: tracing::Span,
@@ -54,9 +64,11 @@ pub struct ServerPrepare<C, Effect, Log = LogInit, State = StateNotReady, Gracef
     _phantom: PhantomData<(Log, State)>,
 }
 
-impl<C, FutEffect, Log, State, Graceful, Decorator> ServerPrepare<C, FutEffect, Log, State, Graceful, Decorator> {
+impl<C, FutEffect, Log, State, Graceful, Decorator>
+    ServerPrepare<C, FutEffect, Log, State, Graceful, Decorator>
+{
     fn new(
-        prepares: SerialPrepareSet<C, FutEffect,Decorator>,
+        prepares: SerialPrepareSet<C, FutEffect, Decorator>,
         graceful: Graceful,
         #[cfg(feature = "logger")] span: tracing::Span,
         #[cfg(not(feature = "logger"))] span: crate::fake_span::FakeSpan,
@@ -70,14 +82,18 @@ impl<C, FutEffect, Log, State, Graceful, Decorator> ServerPrepare<C, FutEffect, 
     }
 }
 
-impl<C, FutEffect, State, Graceful, Decorator> ServerPrepare<C, FutEffect, NoLog, State, Graceful, Decorator>
-    where
-        C: LoggerInitialization,
+type LogResult<C, FutEffect, LogInit, State, Graceful, Decorator> = Result<
+    ServerPrepare<C, FutEffect, LogInit, State, Graceful, Decorator>,
+    <C as LoggerInitialization>::Error,
+>;
+
+impl<C, FutEffect, State, Graceful, Decorator>
+    ServerPrepare<C, FutEffect, NoLog, State, Graceful, Decorator>
+where
+    C: LoggerInitialization,
 {
     /// init the logger of this [ServerPrepare] ,require C impl [LoggerInitialization]
-    pub fn init_logger(
-        self,
-    ) -> Result<ServerPrepare<C, FutEffect, LogInit, State, Graceful,Decorator>, C::Error> {
+    pub fn init_logger(self) -> LogResult<C, FutEffect, LogInit, State, Graceful, Decorator> {
         self.span.in_scope(|| {
             let t = self.prepares.get_ref_configure().init_logger();
             info!(logger = "Init");
@@ -88,19 +104,28 @@ impl<C, FutEffect, State, Graceful, Decorator> ServerPrepare<C, FutEffect, NoLog
     }
 }
 
-impl<C: 'static> ServerPrepare<C, ContainerResult<(), Identity>, NoLog, StateNotReady, NoGraceful, EmptyDecorator> {
+impl<C: 'static>
+    ServerPrepare<
+        C,
+        ContainerResult<(), Identity>,
+        NoLog,
+        StateNotReady,
+        NoGraceful,
+        EmptyDecorator,
+    >
+{
     /// prepare staring the service with config
     pub fn with_config(config: C) -> Self {
         #[cfg(feature = "logger")]
-            let span = tracing::debug_span!("prepare server start");
+        let span = tracing::debug_span!("prepare server start");
         #[cfg(not(feature = "logger"))]
-            let span = crate::fake_span::FakeSpan;
+        let span = crate::fake_span::FakeSpan;
         ServerPrepare::new(SerialPrepareSet::new(Arc::new(config)), NoGraceful, span)
     }
 }
 
 impl<C: 'static, Log, State, Graceful, R, L, Decorator>
-ServerPrepare<C, ContainerResult<R, L>, Log, StateReady<State>, Graceful, Decorator>
+    ServerPrepare<C, ContainerResult<R, L>, Log, StateReady<State>, Graceful, Decorator>
 {
     /// prepare to start this server
     ///
@@ -110,33 +135,33 @@ ServerPrepare<C, ContainerResult<R, L>, Log, StateReady<State>, Graceful, Decora
         self,
     ) -> Result<
         ServerReady<
-            impl Future<Output=Result<(), hyper::Error>>,
-            impl Future<Output=Result<(), hyper::Error>>,
+            impl Future<Output = Result<(), hyper::Error>>,
+            impl Future<Output = Result<(), hyper::Error>>,
         >,
         PrepareStartError,
     >
-        where
+    where
         // config
-            C: BindServe + ConfigureServerEffect<<C as BindServe>::A>,
-            <C::A as Accept>::Conn: AsyncRead + AsyncWrite + Send + Sync + Unpin,
-            <C::A as Accept>::Error: Send + Sync + std::error::Error,
+        C: BindServe + ConfigureServerEffect<<C as BindServe>::A>,
+        <C::A as Accept>::Conn: AsyncRead + AsyncWrite + Send + Sync + Unpin,
+        <C::A as Accept>::Error: Send + Sync + std::error::Error,
         // middleware
-            L: Send + 'static,
-            ServiceBuilder<L>: Layer<Route> + Clone,
-            <ServiceBuilder<L> as Layer<Route>>::Service: Send
+        L: Send + 'static,
+        ServiceBuilder<L>: Layer<Route> + Clone,
+        <ServiceBuilder<L> as Layer<Route>>::Service: Send
             + Clone
-            + Service<Request<Body>, Response=Response<NewResBody>, Error=Infallible>
+            + Service<Request<Body>, Response = Response<NewResBody>, Error = Infallible>
             + 'static,
-            <<ServiceBuilder<L> as Layer<Route>>::Service as Service<Request<Body>>>::Future: Send,
-            NewResBody: http_body::Body<Data=Bytes> + Send + 'static,
-            NewResBody::Error: Into<BoxError>,
+        <<ServiceBuilder<L> as Layer<Route>>::Service as Service<Request<Body>>>::Future: Send,
+        NewResBody: http_body::Body<Data = Bytes> + Send + 'static,
+        NewResBody::Error: Into<BoxError>,
         // prepare task
-            R: PrepareRouteEffect<State, Body>,
+        R: PrepareRouteEffect<State, Body>,
         // state
-            State: FromStateCollector,
-            State: Clone + Send + 'static + Sync,
+        State: FromStateCollector,
+        State: Clone + Send + 'static + Sync,
         // graceful
-            Graceful: FetchGraceful,
+        Graceful: FetchGraceful,
     {
         self.preparing().await
     }
@@ -147,33 +172,33 @@ ServerPrepare<C, ContainerResult<R, L>, Log, StateReady<State>, Graceful, Decora
         self,
     ) -> Result<
         ServerReady<
-            impl Future<Output=Result<(), hyper::Error>>,
-            impl Future<Output=Result<(), hyper::Error>>,
+            impl Future<Output = Result<(), hyper::Error>>,
+            impl Future<Output = Result<(), hyper::Error>>,
         >,
         PrepareStartError,
     >
-        where
+    where
         // config
-            C: BindServe + ConfigureServerEffect<<C as BindServe>::A>,
-            <C::A as Accept>::Conn: AsyncRead + AsyncWrite + Send + Sync + Unpin,
-            <C::A as Accept>::Error: Send + Sync + std::error::Error,
+        C: BindServe + ConfigureServerEffect<<C as BindServe>::A>,
+        <C::A as Accept>::Conn: AsyncRead + AsyncWrite + Send + Sync + Unpin,
+        <C::A as Accept>::Error: Send + Sync + std::error::Error,
         // middleware
-            L: Send + 'static,
-            ServiceBuilder<L>: Layer<Route> + Clone,
-            <ServiceBuilder<L> as Layer<Route>>::Service: Send
+        L: Send + 'static,
+        ServiceBuilder<L>: Layer<Route> + Clone,
+        <ServiceBuilder<L> as Layer<Route>>::Service: Send
             + Clone
-            + Service<Request<Body>, Response=Response<NewResBody>, Error=Infallible>
+            + Service<Request<Body>, Response = Response<NewResBody>, Error = Infallible>
             + 'static,
-            <<ServiceBuilder<L> as Layer<Route>>::Service as Service<Request<Body>>>::Future: Send,
-            NewResBody: http_body::Body<Data=Bytes> + Send + 'static,
-            NewResBody::Error: Into<BoxError>,
+        <<ServiceBuilder<L> as Layer<Route>>::Service as Service<Request<Body>>>::Future: Send,
+        NewResBody: http_body::Body<Data = Bytes> + Send + 'static,
+        NewResBody::Error: Into<BoxError>,
         // prepare task
-            R: PrepareRouteEffect<State, Body>,
+        R: PrepareRouteEffect<State, Body>,
         // state
-            State: FromStateCollector,
-            State: Clone + Send + 'static + Sync,
+        State: FromStateCollector,
+        State: Clone + Send + 'static + Sync,
         // graceful
-            Graceful: FetchGraceful,
+        Graceful: FetchGraceful,
     {
         async {
             let (prepare_fut, configure) = self.prepares.unwrap();
@@ -212,16 +237,16 @@ ServerPrepare<C, ContainerResult<R, L>, Log, StateReady<State>, Graceful, Decora
                 None => ServerReady::Server(server),
             })
         }
-            .pipe(|fut| {
-                #[cfg(feature = "logger")]
-                {
-                    tracing::Instrument::instrument(fut, self.span)
-                }
-                #[cfg(not(feature = "logger"))]
-                {
-                    fut
-                }
-            })
-            .await
+        .pipe(|fut| {
+            #[cfg(feature = "logger")]
+            {
+                tracing::Instrument::instrument(fut, self.span)
+            }
+            #[cfg(not(feature = "logger"))]
+            {
+                fut
+            }
+        })
+        .await
     }
 }

--- a/src/server_prepare/mod.rs
+++ b/src/server_prepare/mod.rs
@@ -91,8 +91,6 @@ impl<C, FutEffect, State, Graceful> ServerPrepare<C, FutEffect, NoLog, State, Gr
 impl<C: 'static> ServerPrepare<C, ContainerResult<(), Identity>, NoLog, StateNotReady, NoGraceful> {
     /// prepare staring the service with config
     pub fn with_config(config: C) -> Self
-        where
-            C: ServeAddress,
     {
         #[cfg(feature = "logger")]
             let span = tracing::debug_span!("prepare server start");

--- a/src/server_prepare/mod.rs
+++ b/src/server_prepare/mod.rs
@@ -37,6 +37,7 @@ mod graceful_shutdown;
 mod state_ready;
 
 mod configure;
+mod decorator;
 
 pub struct NoLog;
 

--- a/src/server_prepare/mod.rs
+++ b/src/server_prepare/mod.rs
@@ -107,7 +107,7 @@ ServerPrepare<C, ContainerResult<R, L>, Log, StateReady<State>, Graceful>
 {
     /// prepare to start this server
     ///
-    /// this will consume `Self` then return [ServerReady](crate::ServerReady)
+    /// using [`ServerPrepare::preparing`]
     #[deprecated]
     pub async fn prepare_start<NewResBody>(
         self,

--- a/src/server_prepare/state_ready.rs
+++ b/src/server_prepare/state_ready.rs
@@ -5,7 +5,7 @@ use crate::{prepare_behave::FromStateCollector, ServerPrepare};
 pub struct StateNotReady;
 pub struct StateReady<S>(PhantomData<S>);
 
-impl<C, FutEffect, Log, Graceful> ServerPrepare<C, FutEffect, Log, StateNotReady, Graceful> {
+impl<C, FutEffect, Log, Graceful,Decorator> ServerPrepare<C, FutEffect, Log, StateNotReady, Graceful,Decorator> {
     /// convert internal [`StateCollector`](crate::StateCollector) to special
     /// State
     pub fn convert_state<S: FromStateCollector>(

--- a/src/server_prepare/state_ready.rs
+++ b/src/server_prepare/state_ready.rs
@@ -10,7 +10,7 @@ impl<C, FutEffect, Log, Graceful,Decorator> ServerPrepare<C, FutEffect, Log, Sta
     /// State
     pub fn convert_state<S: FromStateCollector>(
         self,
-    ) -> ServerPrepare<C, FutEffect, Log, StateReady<S>, Graceful> {
+    ) -> ServerPrepare<C, FutEffect, Log, StateReady<S>, Graceful,Decorator> {
         ServerPrepare {
             prepares: self.prepares,
             graceful: self.graceful,
@@ -19,7 +19,7 @@ impl<C, FutEffect, Log, Graceful,Decorator> ServerPrepare<C, FutEffect, Log, Sta
         }
     }
     /// convenient function for [`ServerPrepare::convert_state::<()>`](axum_starter::ServerPrepare::convert_state)
-    pub fn no_state(self) -> ServerPrepare<C, FutEffect, Log, StateReady<()>, Graceful> {
+    pub fn no_state(self) -> ServerPrepare<C, FutEffect, Log, StateReady<()>, Graceful,Decorator> {
         self.convert_state::<()>()
     }
 }

--- a/src/server_prepare/state_ready.rs
+++ b/src/server_prepare/state_ready.rs
@@ -5,12 +5,14 @@ use crate::{prepare_behave::FromStateCollector, ServerPrepare};
 pub struct StateNotReady;
 pub struct StateReady<S>(PhantomData<S>);
 
-impl<C, FutEffect, Log, Graceful,Decorator> ServerPrepare<C, FutEffect, Log, StateNotReady, Graceful,Decorator> {
+impl<C, FutEffect, Log, Graceful, Decorator>
+    ServerPrepare<C, FutEffect, Log, StateNotReady, Graceful, Decorator>
+{
     /// convert internal [`StateCollector`](crate::StateCollector) to special
     /// State
     pub fn convert_state<S: FromStateCollector>(
         self,
-    ) -> ServerPrepare<C, FutEffect, Log, StateReady<S>, Graceful,Decorator> {
+    ) -> ServerPrepare<C, FutEffect, Log, StateReady<S>, Graceful, Decorator> {
         ServerPrepare {
             prepares: self.prepares,
             graceful: self.graceful,
@@ -19,7 +21,7 @@ impl<C, FutEffect, Log, Graceful,Decorator> ServerPrepare<C, FutEffect, Log, Sta
         }
     }
     /// convenient function for [`ServerPrepare::convert_state::<()>`](axum_starter::ServerPrepare::convert_state)
-    pub fn no_state(self) -> ServerPrepare<C, FutEffect, Log, StateReady<()>, Graceful,Decorator> {
+    pub fn no_state(self) -> ServerPrepare<C, FutEffect, Log, StateReady<()>, Graceful, Decorator> {
         self.convert_state::<()>()
     }
 }


### PR DESCRIPTION
- [x] [feature] support more kind of `Accept`
  - [x] trait `BindServe` to bind an Accept
  - [x] support old trait `ServiceAddress` 
  - [x] derive macro `Configure` support without `address` argument
  - [x] `ServiceConfigure` contain generic argument `A`
- [x] [feature] support add decorator on each prepare task
  - [x] trait `PrepareDecorator` to set decotrator
  - [x] add set decorator support
  - [x] decorator support in `prepare_*`
- [x] others
  - [x] change `perpare_start` to `preparing`, old one become deperated 
  - [x] change `PrepareError` format message 